### PR TITLE
Update OpenCV includes.

### DIFF
--- a/rviz_cinematographer_view_controller/include/rviz_cinematographer_view_controller/rviz_cinematographer_view_controller.h
+++ b/rviz_cinematographer_view_controller/include/rviz_cinematographer_view_controller/rviz_cinematographer_view_controller.h
@@ -73,8 +73,6 @@
 
 #include <boost/circular_buffer.hpp>
 
-#include <cv.hpp>
-
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
 

--- a/video_recorder/include/video_recorder/video_recorder.h
+++ b/video_recorder/include/video_recorder/video_recorder.h
@@ -25,7 +25,8 @@
 
 #include <boost/thread.hpp>
 
-#include <cv.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/videoio/videoio.hpp>
 
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>


### PR DESCRIPTION
I needed to remove references to `cv.hpp` to run on Ubuntu 20.04 + ROS Noetic.